### PR TITLE
Add Japanese word Markov chain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # OpenAI-Codex-
 OpenAIのCodexを試したいリポジトリ。サンプルプログラムでは「Hello, Work! 無職万歳！」を表示します。
+
+## Markov Chain Example
+`markov_chain.c` はシャノンの「通信の数学的理論」で用いられるようなマルコフ連鎖を簡単に再現したものです。遷移確率行列を使って文字列を生成します。
+
+## Japanese Word Markov Chain Example
+`word_markov_chain.c` は指定された単語群からマルコフ連鎖を構成し、ランダムに文を生成します。
+コンパイルして実行すると、たとえば「あなたのメロンを食べます」のような文章が表示されます。

--- a/markov_chain.c
+++ b/markov_chain.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+/* Simple Markov chain text generator
+ * Demonstrates Shannon's model from "A Mathematical Theory of Communication".
+ * States are characters, transitions define the probability of the next state.
+ */
+
+#define STATES 4
+
+static const char symbols[STATES] = {'A', 'B', 'C', 'D'};
+
+/* Transition probability matrix.
+ * Each row sums to 1.0. For simplicity we use double precision.
+ */
+static const double transition[STATES][STATES] = {
+    /* From A */ {0.1, 0.6, 0.2, 0.1},
+    /* From B */ {0.3, 0.1, 0.4, 0.2},
+    /* From C */ {0.25, 0.25, 0.25, 0.25},
+    /* From D */ {0.5, 0.2, 0.2, 0.1}
+};
+
+/* Randomly select the next state based on probabilities */
+static int next_state(int current) {
+    double r = (double)rand() / RAND_MAX;
+    double cumulative = 0.0;
+    for (int i = 0; i < STATES; ++i) {
+        cumulative += transition[current][i];
+        if (r < cumulative)
+            return i;
+    }
+    return STATES - 1; /* Fallback */
+}
+
+int main(void) {
+    srand((unsigned)time(NULL));
+
+    int current = 0; /* Start from state 'A' */
+    const int steps = 20; /* Length of generated sequence */
+
+    for (int i = 0; i < steps; ++i) {
+        putchar(symbols[current]);
+        current = next_state(current);
+    }
+    putchar('\n');
+
+    return 0;
+}

--- a/word_markov_chain.c
+++ b/word_markov_chain.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+static const char *group0[] = {"わたし", "あなた", "おまえ"};
+static const char *group1[] = {"は", "の"};
+static const char *group2[] = {"りんご", "みかん", "いちご", "スイカ", "メロン", "さくらんぼ", "かき", "なし", "もも"};
+static const char *group3[] = {"が", "を"};
+static const char *group4[] = {"好きです", "嫌いです", "食べます", "捨てます", "腐ってます"};
+
+#define SIZE(arr) (sizeof(arr)/sizeof((arr)[0]))
+
+int main(void) {
+    const char **groups[] = {group0, group1, group2, group3, group4};
+    const size_t sizes[] = {SIZE(group0), SIZE(group1), SIZE(group2), SIZE(group3), SIZE(group4)};
+    const int group_count = 5;
+
+    srand((unsigned)time(NULL));
+
+    for (int g = 0; g < group_count; ++g) {
+        size_t n = sizes[g];
+        const char **words = groups[g];
+        int index = rand() % n;
+        printf("%s", words[index]);
+    }
+    putchar('\n');
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `word_markov_chain.c` demonstrating a simple word-based chain
- document the new example in README

## Testing
- `gcc -Wall -Wextra -std=c11 word_markov_chain.c -o word_markov_chain`
- `./word_markov_chain`
- `gcc -Wall -Wextra -std=c11 markov_chain.c -o markov_chain`
- `./markov_chain`
