### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build C Programs
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build essentials
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+      - name: Compile all C files
+        run: |
+          set -euxo pipefail
+          for file in *.c; do
+            echo "Compiling $file";
+            gcc -std=c11 -Wall -Wextra -Werror "$file" -o "$(basename "$file" .c)";
+          done
+


### PR DESCRIPTION
## Summary
- build all C files on push and PR using GitHub Actions

## Testing
- `gcc -std=c11 -Wall -Wextra -Werror hello.c -o /tmp/hello`
- `gcc -std=c11 -Wall -Wextra -Werror h_janken.c -o /tmp/h_janken`
- `gcc -std=c11 -Wall -Wextra -Werror markov_chain.c -o /tmp/markov_chain`
- `gcc -std=c11 -Wall -Wextra -Werror rebel_game.c -o /tmp/rebel_game`
- `gcc -std=c11 -Wall -Wextra -Werror word_markov_chain.c -o /tmp/word_markov_chain`
